### PR TITLE
#18: Add support for story points estimation at issue description

### DIFF
--- a/app/accepted_emoji.rb
+++ b/app/accepted_emoji.rb
@@ -20,4 +20,8 @@ module Accepted_Time_Tracking_Emoji
 		acceptedNonBilliableEmoji = [":dart:"]
 	end
 
+        def self.accepted_issue_points_emoji
+                [":point_up:"]
+        end
+
 end

--- a/app/app.rb
+++ b/app/app.rb
@@ -60,6 +60,10 @@ helpers do
 		issue_stat_queries.get_milestone_sums(downloadID, milestoneNumber)
 	end
 
+        def get_milestone_points(downloadID, milestoneNumber)
+                issue_stat_queries.get_milestone_points(downloadID, milestoneNumber)
+        end
+
 	def issue_stat_queries
 		if @isq == nil
 			@isq = Issue_Stat_Queries.new(mongoConnection)
@@ -117,13 +121,14 @@ get '/download-xlsx/:downloadID' do
 		dataExportConnection = XLSXExporter.new(mongoConnection)
 		dataExportIssues = dataExportConnection.get_all_issues_time(downloadID)
 		dataExportMilestones = dataExportConnection.get_all_milestone_budgets(downloadID)
+                dataExportStoryPoints = dataExportConnection.get_all_story_points(downloadID)
 
-		if dataExportIssues.empty? == false or dataExportMilestones.empty? == false
+                if dataExportIssues.empty? == false or dataExportMilestones.empty? == false or dataExportStoryPoints.empty? == false
 
 			content_type 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
 			attachment 'time-tracking.xlsx'
 
-			file = dataExportConnection.generateXLSX(dataExportIssues, dataExportMilestones)
+			file = dataExportConnection.generateXLSX(dataExportIssues, dataExportMilestones, dataExportStoryPoints)
 		else
 			flash[:danger] = ["Unable to generate a xlsx: No time tracking data has been downloaded"]
 			redirect '/'

--- a/app/gitlab_downloader.rb
+++ b/app/gitlab_downloader.rb
@@ -62,11 +62,12 @@ class GitLab_Downloader
 				x["created_at"] = DateTime.strptime(x["created_at"], '%Y-%m-%dT%H:%M:%S.%L%z').to_time.utc
 				x["updated_at"] = DateTime.strptime(x["updated_at"], '%Y-%m-%dT%H:%M:%S.%L%z').to_time.utc
 
+                                x = Gl_Issue.process_description(x);
+
 				commentPageNum = 1
 				issueComments = @glClient.issue_notes(x["project_id"], x["id"], :per_page=>100, :page=>commentPageNum)	# Gets the notes for the current issue
 
-
-				if issueComments.length > 0	# If there are notes in the issue then...
+				if issueComments.length > 0 || x['points'] > 0	# If there are notes in the issue then...
 					comments2 = []	# Array used to hold comments with time tracking information.
 
 
@@ -91,7 +92,7 @@ class GitLab_Downloader
 					end
 
 					# if there are comments with time tracking information then....
-					if comments2.length > 0
+                                        if x['points'] > 0 || comments2.length > 0
 											# If there is milestone data then....
 						if x["milestone"] != nil
 							x["milestone"]["created_at"] = DateTime.strptime(x["milestone"]["created_at"], '%Y-%m-%dT%H:%M:%S.%L%z').to_time.utc

--- a/app/helpers.rb
+++ b/app/helpers.rb
@@ -16,9 +16,17 @@ module Helpers
 		return Accepted_Time_Tracking_Emoji.accepted_nonBillable_emoji
 	end
 
+        def self.get_Issue_Points_Emoji
+            return Accepted_Time_Tracking_Emoji.accepted_issue_points_emoji
+        end
+
 	def self.get_duration(durationText)
 		return ChronicDuration.parse(durationText)
 	end
+
+        def self.get_points(pointText) 
+            return pointText
+        end
 
 	def self.get_time_work_date(parsedTimeComment)
 		begin
@@ -35,6 +43,14 @@ module Helpers
 	def self.parse_billable_time_comment(timeComment, timeEmoji)
 		return timeComment.gsub("#{timeEmoji} ","").split(" | ")
 	end
+
+        def self.parse_points_message(issueDescription, pointsEmoji)
+            return issueDescription.
+                split("\n").
+                find{ |s| s[/^#{pointsEmoji}/] }.
+                gsub("#{pointsEmoji} ","").
+                split(" | ")
+        end
 
 	def self.get_time_commit_comment(parsedTimeComment)
 		return parsedTimeComment.lstrip.gsub("\r\n", " ")
@@ -59,6 +75,12 @@ module Helpers
 
 		acceptedClockEmoji.any? { |w| commentBody =~ /\A#{w}/ }
 	end
+
+        # Is it a points comment?  Returns True or False
+        def self.points_message?(commentBody)
+                acceptedPointEmoji = Accepted_Time_Tracking_Emoji.accepted_issue_points_emoji
+                acceptedPointEmoji.any? { |w| commentBody =~ /^#{w}/m }
+        end
 
 
 	# TODO Rebuild for GitLab

--- a/app/issue_time.rb
+++ b/app/issue_time.rb
@@ -27,6 +27,37 @@ module Gl_Issue_Time
 		end
 	end
 
+        # processes a comment for points
+        def self.process_issue_message_for_points(issue)
+                issueBody = issue["description"]
+                return parse_points_message(issueBody)
+        end
+
+        def self.parse_points_message(pointsMessage) 
+            acceptedPointEmoji = Helpers.get_Issue_Points_Emoji
+
+            parsedMessageHash = { "points_comment" => nil, "points" => nil };
+            parsedMessage = [];
+
+            acceptedPointEmoji.each do |x|
+                parsedMessage = Helpers.parse_points_message(pointsMessage, x)
+            end
+
+            if parsedMessage.empty? == true
+                return nil
+            end
+            if parsedMessage[0] != nil
+                parsedMessageHash['points'] = Helpers.get_points(parsedMessage[0]);
+            end
+
+            if parsedMessage[1] != nil
+                parsedMessageHash['points_comment'] = Helpers.get_time_commit_comment(parsedMessage[1])
+            end
+
+            return parsedMessageHash;
+
+        end
+
 	def self.parse_time_commit(timeComment, nonBillableTime)
 		acceptedClockEmoji = Helpers.get_Issue_Time_Emoji
 		acceptedNonBilliableEmoji = Helpers.get_Non_Billable_Emoji

--- a/app/issues.rb
+++ b/app/issues.rb
@@ -7,6 +7,25 @@ require_relative 'issue_time'
 
 module Gl_Issue
 
+        def self.process_description(issue) 
+            includesPointsInfo = Helpers.points_message?(issue['description'])
+
+            if includesPointsInfo
+                parsedPoints = Gl_Issue_Time.process_issue_message_for_points(issue);
+                if parsedPoints != nil
+                    issue['points'] = parsedPoints['points'].to_i;
+                    issue['points_comment'] = parsedPoints['points_comment'];
+                    issue['points_points'] = parsedPoints['points'];
+                else
+                    issue['points'] = 0;
+                end
+            else
+                issue['points'] = 0;
+            end
+
+            return issue
+        end
+
 	def self.process_comment(issueComment)
 		bodyField = issueComment["body"]
 		
@@ -29,13 +48,13 @@ module Gl_Issue
 				else
 					return output = nil
 				end
+                        end
 			# Buget Handling
-			# elsif isBudgetComment == true
-			# 	parsedBudget = Gh_Issue_Budget.process_issue_comment_for_budget(x)
-			# 	if parsedBudget != nil
-			# 		commentsTime << parsedBudget
-			# 	end
-			end		
+			#elsif isBudgetComment == true
+			#	parsedBudget = Gh_Issue_Budget.process_issue_comment_for_budget(issueComment)
+			#	if parsedBudget != nil
+			#		commentsTime << parsedBudget
+			#	end
 		# end # do not delete this 'end'.  it is part of issueComments do block
 
 		# if commentsTime.empty? == false

--- a/app/views/analyze.erb
+++ b/app/views/analyze.erb
@@ -17,6 +17,8 @@
 		<p> Budget: <%= budget = m["milestone_budget_duration"].to_i %></p>
 		<p> Due Date: <%= m["milestone_due_date"] %></p>
 		<p> Sum of Time Logs assoicated with Milestone(Spent Time): <%= timeSum = get_milestone_sums(m["download_id"], m["milestone_number"])["time_duration_sum"] %> (<%= (timeSum / budget.to_f * 100).round(2) %> % spent)</p>
+
+                <p> Sum of story points: <%= get_milestone_points(m["download_id"], m["milestone_number"])["points_total"] %></p>
 		<p> Count of Time Logs assoicated with Milestone: <%= timeCount = get_milestone_sums(m["download_id"], m["milestone_number"])["time_comment_count"] %></p>
 		<p>Budget Left: <%= budget - timeSum %> (<%= ((budget - timeSum) / budget.to_f * 100).round(2) %>% left) </p>
 
@@ -27,6 +29,7 @@
 					<th class="text-center">Issue Title</th>
 					<th class="text-center">Issue State</th>
 					<th class="text-center">Time Duration Sum</th>
+                                        <th class="text-center">Story points</th>
 					<th class="text-center">Time Log Count</th>
 				</tr>
 				<% get_issues_for_milestone(m["download_id"], m["milestone_number"]).each do |i| %>
@@ -35,6 +38,7 @@
 						<td class="text-center"><%= i["issue_title"] %></td>
 						<td class="text-center"><%= i["issue_state"] %></td>
 						<td class="text-center"><%= i["time_duration_sum"] %> (<%= (i["time_duration_sum"] / budget.to_f * 100).round(2)%>% of Budget)</td>
+                                                <td class="text-center"><%= i["issue_points"] %></td>
 						<td class="text-center"><%= i["time_comment_count"] %></td>
 					</tr>					
 				<% end %>


### PR DESCRIPTION
This is implementation of proposal for story points support. If user will use special emoji in issue description (it has to be separate line somewhere in description), then additional information about story points will be added to issue.

Example entry:
:point_up: 3 | Story point estimation

I'm not a ruby programmer, so I tried to use existing patterns, and code quality will need some review and refactoring, but at least proof of concept seems to work. 
